### PR TITLE
Replaced bitbucket references.

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"bitbucket.org/michaellockwood/github-repos/sourcecontrol/github"
-	"bitbucket.org/michaellockwood/github-repos/sourcecontrol"
+	"github.com/michaellockwood/github-repos/sourcecontrol/github"
+	"github.com/michaellockwood/github-repos/sourcecontrol"
 	"time"
 	"os"
 )

--- a/sourcecontrol/github/commits.go
+++ b/sourcecontrol/github/commits.go
@@ -1,7 +1,7 @@
 package github
 
 import (
-	"bitbucket.org/michaellockwood/github-repos/sourcecontrol"
+	"github.com/michaellockwood/github-repos/sourcecontrol"
 	"time"
 	"fmt"
 )

--- a/sourcecontrol/github/commits_integration_test.go
+++ b/sourcecontrol/github/commits_integration_test.go
@@ -2,7 +2,7 @@ package github_test
 
 import (
 	"testing"
-	"bitbucket.org/michaellockwood/github-repos/sourcecontrol/github"
+	"github.com/michaellockwood/github-repos/sourcecontrol/github"
 	"time"
 )
 

--- a/sourcecontrol/github/repoistories_integration_test.go
+++ b/sourcecontrol/github/repoistories_integration_test.go
@@ -2,7 +2,7 @@ package github_test
 
 import (
 	"testing"
-	"bitbucket.org/michaellockwood/github-repos/sourcecontrol/github"
+	"github.com/michaellockwood/github-repos/sourcecontrol/github"
 	"time"
 )
 

--- a/sourcecontrol/github/repositories.go
+++ b/sourcecontrol/github/repositories.go
@@ -2,7 +2,7 @@ package github
 
 import (
 	"time"
-	"bitbucket.org/michaellockwood/github-repos/sourcecontrol"
+	"github.com/michaellockwood/github-repos/sourcecontrol"
 	"fmt"
 )
 

--- a/sourcecontrol/mock_sourcecontrol/mock_sourcecontrol.go
+++ b/sourcecontrol/mock_sourcecontrol/mock_sourcecontrol.go
@@ -4,7 +4,7 @@
 package mock_sourcecontrol
 
 import (
-	sourcecontrol "bitbucket.org/michaellockwood/github-repos/sourcecontrol"
+	sourcecontrol "github.com/michaellockwood/github-repos/sourcecontrol"
 	gomock "github.com/golang/mock/gomock"
 )
 

--- a/sourcecontrol/sourcecontrol_test.go
+++ b/sourcecontrol/sourcecontrol_test.go
@@ -2,10 +2,10 @@ package sourcecontrol_test
 
 import (
 	"testing"
-	"bitbucket.org/michaellockwood/github-repos/sourcecontrol"
+	"github.com/michaellockwood/github-repos/sourcecontrol"
 	"github.com/golang/mock/gomock"
 	"time"
-	"bitbucket.org/michaellockwood/github-repos/sourcecontrol/mock_sourcecontrol"
+	"github.com/michaellockwood/github-repos/sourcecontrol/mock_sourcecontrol"
 )
 
 func TestGetRepositoriesWithCommits_CommitsAreReturned(t *testing.T) {


### PR DESCRIPTION
Hi Michael,

I couldn't run your example. I guess you moved it from bitbucket to github, but references were still pointing to bitbucket account which I don't have access to.

I've used github references and app run without any problems.

o.
